### PR TITLE
Add a note in the docs about thread safety of `#parse_wkt`

### DIFF
--- a/lib/rgeo/feature/factory.rb
+++ b/lib/rgeo/feature/factory.rb
@@ -115,6 +115,9 @@ module RGeo
 
       # Parse the given string in well-known-text format and return the
       # resulting feature. Returns nil if the string couldn't be parsed.
+      # NOTE: most implementations of this method are not thread-safe,
+      # so it's not advisable to use a class-level constant for a factory
+      # if you're using Puma or another threaded web server.
 
       def parse_wkt(str_)
         nil


### PR DESCRIPTION
Since the parser is an ivar, and the parser has its own internal state, it's not safe to re-use an instance of a factory, e.g. as a class-level constant, to do parsing.

This is probably true for other methods as well, but `#parse_wkt` was the one I ran into this problem.